### PR TITLE
Fix thrown exception

### DIFF
--- a/src/Operations/Messages.php
+++ b/src/Operations/Messages.php
@@ -145,9 +145,9 @@ class Messages extends AOperation
         );
 
         $message = json_decode($message);
-
+        
         if (!$message) {
-            throw new MailosaurException('Email message not found.');
+            throw new \Exception('Email message not found.');
         }
 
         return new Message($message);

--- a/tests/EmailsTests.php
+++ b/tests/EmailsTests.php
@@ -2,7 +2,6 @@
 
 namespace MailosaurTest;
 
-
 use Mailosaur\MailosaurClient;
 use Mailosaur\Models\Message;
 use Mailosaur\Models\MessageSummary;
@@ -69,6 +68,22 @@ class EmailsTests extends \PHPUnit\Framework\TestCase
         $email = $this->client->messages->waitFor($this->server, $criteria);
 
         $this->validateEmail($email);
+    }
+
+    public function testWaitForThrowsException()
+    {
+        $this->expectExceptionMessage('Email message not found.');
+
+        $host             = ($h = getenv('MAILOSAUR_SMTP_HOST')) ? $h : 'mailosaur.io';
+        $sendEmailAddress = 'found.' . $this->server . '@' . $host;
+        $testEmailAddress = 'not_found.' . $this->server . '@' . $host;
+
+        Mailer::sendEmail($this->client, $this->server, $sendEmailAddress);
+
+        $criteria         = new SearchCriteria();
+        $criteria->sentTo = $testEmailAddress;
+
+        $email = $this->client->messages->waitFor($this->server, $criteria);
     }
 
     public function testSearchNoCriteriaError()


### PR DESCRIPTION
This PR will fix the message returned by waitFor to `Email message not found.` if indeed given email was not found.
Currently `Unspecified error.` is returned due to usage of MailosaurException