### PR TITLE
Intellisense: doc comments and inbox (server) terminology

### DIFF
--- a/src/MailosaurClient.php
+++ b/src/MailosaurClient.php
@@ -33,7 +33,7 @@ class MailosaurClient
     public $messages;
 
     /**
-     * Operations for creating and managing your Mailosaur servers (virtual inboxes).
+     * Operations for creating and managing your Mailosaur inboxes (servers).
      *
      * @var Operations\Servers
      */

--- a/src/MailosaurClient.php
+++ b/src/MailosaurClient.php
@@ -11,6 +11,12 @@ use Mailosaur\Operations\Usage;
 use Mailosaur\Operations\Devices;
 use Mailosaur\Operations\Previews;
 
+/**
+ * The Mailosaur client — the main entry point to the Mailosaur API. Construct an instance with
+ * your API key (or set the `MAILOSAUR_API_KEY` environment variable), then use the operations
+ * namespaces (`messages`, `servers`, `files`, `analysis`, `usage`, `devices`, `previews`) to
+ * automate email and SMS testing.
+ */
 class MailosaurClient
 {
     /** @var string */
@@ -19,28 +25,64 @@ class MailosaurClient
     /** @var string The base URI of the service. */
     protected $baseUri;
 
-    /** @var Operations\Messages */
+    /**
+     * Operations for finding, retrieving, creating, and managing email and SMS messages.
+     *
+     * @var Operations\Messages
+     */
     public $messages;
 
-    /** @var Operations\Servers */
+    /**
+     * Operations for creating and managing your Mailosaur servers (virtual inboxes).
+     *
+     * @var Operations\Servers
+     */
     public $servers;
 
-    /** @var Operations\Files */
+    /**
+     * Operations for downloading attachments, EML source, and email preview screenshots.
+     *
+     * @var Operations\Files
+     */
     public $files;
 
-    /** @var Operations\Analysis */
+    /**
+     * Operations for analyzing email content and deliverability, including spam scoring.
+     *
+     * @var Operations\Analysis
+     */
     public $analysis;
 
-    /** @var Operations\Usage */
+    /**
+     * Operations for inspecting account usage limits and recent transactional usage.
+     *
+     * @var Operations\Usage
+     */
     public $usage;
 
-    /** @var Operations\Devices */
+    /**
+     * Operations for managing virtual security devices and retrieving their one-time passwords.
+     *
+     * @var Operations\Devices
+     */
     public $devices;
 
-    /** @var Operations\Previews */
+    /**
+     * Operations for discovering the email clients available for generating email previews.
+     *
+     * @var Operations\Previews
+     */
     public $previews;
 
 
+    /**
+     * Returns an instance of the Mailosaur client.
+     *
+     * @param string $apiKey  Optional API key. Overrides the MAILOSAUR_API_KEY environment variable if set.
+     * @param string $baseUri Optionally overrides the base URL of the Mailosaur service.
+     *
+     * @throws Models\MailosaurException If no API key can be resolved.
+     */
     public function __construct($apiKey = null, $baseUri = 'https://mailosaur.com/')
     {
         $resolvedApiKey = $apiKey ?: getenv('MAILOSAUR_API_KEY');

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -66,7 +66,7 @@ class Message
     public $metadata;
 
     /**
-     * @var string Identifier for the server in which the message is located.
+     * @var string Identifier for the inbox (server) in which the message is located.
      */
     public $server;
 

--- a/src/Models/MessageSummary.php
+++ b/src/Models/MessageSummary.php
@@ -16,7 +16,7 @@ class MessageSummary
     public $type;
 
     /**
-     * @var string Identifier for the server in which the message is located.
+     * @var string Identifier for the inbox (server) in which the message is located.
      */
     public $server;
 

--- a/src/Models/Server.php
+++ b/src/Models/Server.php
@@ -5,16 +5,16 @@ namespace Mailosaur\Models;
 
 class Server
 {
-    /** @var string Unique identifier for the server. Used as username for SMTP/POP3 authentication. */
+    /** @var string Unique identifier for the inbox (server). Used as username for SMTP/POP3 authentication. */
     public $id;
 
-    /** @var string A name used to identify the server. */
+    /** @var string The name of the inbox (server). */
     public $name;
 
-    /** @var array Users (excluding administrators) who have access to the server. */
+    /** @var array Users (excluding administrators) who have access to the inbox (server) when access is restricted. */
     public $users = array();
 
-    /** @var int The number of messages currently in the server. */
+    /** @var int The number of messages currently in the inbox (server). */
     public $messages;
 
     public function __construct(\stdClass $data)

--- a/src/Models/ServerCreateOptions.php
+++ b/src/Models/ServerCreateOptions.php
@@ -5,7 +5,7 @@ namespace Mailosaur\Models;
 
 class ServerCreateOptions
 {
-    /** @var string A name used to identify the server. */
+    /** @var string A name used to identify the inbox (server). */
     public $name;
 
     public function __construct($name = null)

--- a/src/Models/ServerListResult.php
+++ b/src/Models/ServerListResult.php
@@ -6,7 +6,7 @@ namespace Mailosaur\Models;
 class ServerListResult
 {
     /**
-     * @var Server[] Servers are returned sorted by creation date, with the most recently-created server appearing first.
+     * @var Server[] Inboxes (servers) are returned sorted by creation date, with the most recently-created inbox (server) appearing first.
      */
     public $items = array();
 

--- a/src/Operations/Analysis.php
+++ b/src/Operations/Analysis.php
@@ -12,14 +12,19 @@ namespace Mailosaur\Operations;
 use Mailosaur\Models\SpamAnalysisResult;
 use Mailosaur\Models\DeliverabilityReport;
 
+/**
+ * Operations for analyzing the content and deliverability of an email, including SpamAssassin
+ * scoring and per-provider deliverability reports. Accessed via `client->analysis`.
+ */
 class Analysis extends AOperation
 {
     /**
      * <strong>Perform a spam test</strong>
+     * <p>Performs a spam analysis of an email.</p>
      *
-     * @param string $email The identifier of the email to be analyzed.
+     * @param string $email The identifier of the message to be analyzed.
      *
-     * @return SpamAnalysisResult
+     * @return SpamAnalysisResult The spam score and filter results.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Analysis_Spam Perform a spam test docs
      * @example https://mailosaur.com/docs/api/#operation/Analysis_Spam
@@ -35,10 +40,11 @@ class Analysis extends AOperation
 
     /**
      * <strong>Perform a deliverability report</strong>
+     * <p>Performs a deliverability report of an email.</p>
      *
-     * @param string $email The identifier of the email to be analyzed.
+     * @param string $email The identifier of the message to be analyzed.
      *
-     * @return DeliverabilityReport
+     * @return DeliverabilityReport The deliverability report for the email.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/analysis Perform a deliverability test docs
      * @example https://mailosaur.com/docs/api/analysis

--- a/src/Operations/Devices.php
+++ b/src/Operations/Devices.php
@@ -8,13 +8,19 @@ use Mailosaur\Models\DeviceCreateOptions;
 use Mailosaur\Models\DeviceListResult;
 use Mailosaur\Models\OtpResult;
 
+/**
+ * Operations for managing virtual security devices and retrieving their current one-time passwords
+ * (OTPs), used to automate testing of app-based multi-factor authentication. Accessed via
+ * `client->devices`.
+ */
 class Devices extends AOperation
 {
 
     /**
      * <strong>List all devices</strong>
+     * <p>Returns a list of your virtual security devices.</p>
      *
-     * @return DeviceListResult
+     * @return DeviceListResult Your devices.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Devices_List List all devices
      * @example https://mailosaur.com/docs/api/#operation/Devices_List
@@ -32,9 +38,9 @@ class Devices extends AOperation
      * <strong>Create a device</strong>
      * <p>Creates a new virtual security device and returns it.</p>
      *
-     * @param $deviceCreateOptions
+     * @param DeviceCreateOptions $deviceCreateOptions Options used to create a new Mailosaur virtual security device.
      *
-     * @return \Mailosaur\Models\Device
+     * @return \Mailosaur\Models\Device The newly-created device.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Devices_Create Create a device
      * @example https://mailosaur.com/docs/api/#operation/Devices_Create
@@ -62,7 +68,7 @@ class Devices extends AOperation
      *
      * @param string $query Either the unique identifier of the device, or a base32-encoded shared secret.
      *
-     * @return \Mailosaur\Models\OtpResult
+     * @return \Mailosaur\Models\OtpResult The current one-time password.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Devices_Otp Retrieve the current one-time password
      * @example https://mailosaur.com/docs/api/#operation/Devices_Otp
@@ -94,9 +100,11 @@ class Devices extends AOperation
 
     /**
      * <strong>Delete a device</strong>
+     * <p>Permanently deletes a virtual security device. This operation cannot be undone.</p>
      *
-     * @param string $id The identifier of the device to be deleted.
+     * @param string $id The unique identifier of the device to be deleted.
      *
+     * @return void
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Devices_Delete Delete a device
      * @example https://mailosaur.com/docs/api/#operation/Devices_Delete

--- a/src/Operations/Files.php
+++ b/src/Operations/Files.php
@@ -4,14 +4,19 @@ namespace Mailosaur\Operations;
 
 use Mailosaur\Models\MailosaurException;
 
+/**
+ * Operations for downloading the raw content associated with a message — file attachments, the
+ * full EML source of an email, and rendered email previews. Accessed via `client->files`.
+ */
 class Files extends AOperation
 {
     /**
      * <strong>Download an attachment</strong>
+     * <p>Downloads a single attachment.</p>
      *
      * @param string $id The identifier of the attachment to be downloaded.
      *
-     * @return string
+     * @return string The attachment's binary content.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Files_GetAttachment Download an attachment documentation
      * @example https://mailosaur.com/docs/api/#operation/Files_GetAttachment
@@ -28,7 +33,7 @@ class Files extends AOperation
      *
      * @param string $id The identifier of the email to be downloaded.
      *
-     * @return string
+     * @return string The raw EML content of the email.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Files_GetEmail Download EML documentation
      * @example https://mailosaur.com/docs/api/#operation/Files_GetEmail
@@ -40,11 +45,14 @@ class Files extends AOperation
 
     /**
      * <strong>Download an email preview</strong>
+     * <p>Downloads a screenshot of your email rendered in a real email client. Simply supply the
+     * unique identifier for the required preview.</p>
      *
-     * @param string $id The identifier of the preview to be downloaded.
+     * @param string $id The identifier of the email preview to be downloaded.
      *
-     * @return string
-     * @throws \Mailosaur\Models\MailosaurException
+     * @return string The preview screenshot image content.
+     * @throws \Mailosaur\Models\MailosaurException With error type `preview_timeout` if the preview is not
+     *                                              generated within the time limit.
      */
     public function getPreview($id)
     {

--- a/src/Operations/Messages.php
+++ b/src/Operations/Messages.php
@@ -14,7 +14,7 @@ use Mailosaur\Models\PreviewListResult;
 
 /**
  * Operations for finding, retrieving, creating, forwarding, replying to, and deleting the
- * email and SMS messages received by your Mailosaur servers. Accessed via `client->messages`.
+ * email and SMS messages received by your Mailosaur inboxes (servers). Accessed via `client->messages`.
  */
 class Messages extends AOperation
 {
@@ -24,7 +24,7 @@ class Messages extends AOperation
      * search criteria is found. This is the most efficient method of looking up a message,
      * therefore we recommend using it wherever possible.</p>
      *
-     * @param string         $server         The identifier of the server hosting the message.
+     * @param string         $server         The identifier of the inbox (server) hosting the message.
      * @param SearchCriteria $searchCriteria The search criteria to use in order to find a match.
      * @param int            $timeout        Specify how long to wait for a matching result (in milliseconds).
      * @param \DateTime      $receivedAfter  Limits results to only messages received after this date/time.
@@ -94,7 +94,7 @@ class Messages extends AOperation
      * <p>Returns a list of your messages in summary form. The summaries are returned sorted by
      * received date, with the most recently-received messages appearing first.</p>
      *
-     * @param string    $server        The identifier of the server hosting the messages.
+     * @param string    $server        The identifier of the inbox (server) hosting the messages.
      * @param int       $page          Used in conjunction with itemsPerPage to support pagination.
      * @param int       $itemsPerPage  A limit on the number of results to be returned per page.
      *                                 Can be set between 1 and 1000 items, the default is 50.
@@ -126,9 +126,9 @@ class Messages extends AOperation
 
     /**
      * <strong>Delete all messages</strong>
-     * <p>Permanently deletes all messages within a server. This operation cannot be undone.</p>
+     * <p>Permanently deletes all messages within an inbox (server). This operation cannot be undone.</p>
      *
-     * @param string $server The identifier of the server to be emptied.
+     * @param string $server The identifier of the inbox (server) to be emptied.
      *
      * @return void
      * @throws MailosaurException
@@ -145,7 +145,7 @@ class Messages extends AOperation
      * <p>Returns a list of messages matching the specified search criteria, in summary form.
      * The messages are returned sorted by received date, with the most recently-received messages appearing first.</p>
      *
-     * @param string         $server         The identifier of the server hosting the messages.
+     * @param string         $server         The identifier of the inbox (server) hosting the messages.
      * @param SearchCriteria $searchCriteria Search criteria
      * @param int            $page           Used in conjunction with itemsPerPage to support pagination.
      * @param int            $itemsPerPage   A limit on the number of results to be returned per page.
@@ -235,7 +235,7 @@ class Messages extends AOperation
      * useful in scenarios where you want an email to trigger a workflow in your
      * product.</p>
      *
-     * @param string               $server               The unique identifier of the required server.
+     * @param string               $server               The unique identifier of the required inbox (server).
      * @param MessageCreateOptions $messageCreateOptions Options to use when creating a new message.
      *
      * @return \Mailosaur\Models\Message The newly-created message.

--- a/src/Operations/Messages.php
+++ b/src/Operations/Messages.php
@@ -12,11 +12,17 @@ use Mailosaur\Models\MessageReplyOptions;
 use Mailosaur\Models\PreviewRequestOptions;
 use Mailosaur\Models\PreviewListResult;
 
+/**
+ * Operations for finding, retrieving, creating, forwarding, replying to, and deleting the
+ * email and SMS messages received by your Mailosaur servers. Accessed via `client->messages`.
+ */
 class Messages extends AOperation
 {
     /**
      * <strong>Retrieve a message using search criteria.</strong>
-     * <p>Returns as soon as a message matching the specified search criteria is found. This is the most efficient method of looking up a message.</p>
+     * <p>Waits for a message to be found, returning as soon as a message matching the specified
+     * search criteria is found. This is the most efficient method of looking up a message,
+     * therefore we recommend using it wherever possible.</p>
      *
      * @param string         $server         The identifier of the server hosting the message.
      * @param SearchCriteria $searchCriteria The search criteria to use in order to find a match.
@@ -25,8 +31,9 @@ class Messages extends AOperation
      * @param string         $dir            Optionally limits results based on the direction (`Sent` or
      *                                       `Received`), with the default being `Received`.
      *
-     * @return Message
-     * @throws MailosaurException
+     * @return Message The first message matching the criteria.
+     * @throws MailosaurException With error type `no_messages_found` if no matching message exists, or
+     *                            `search_timeout` if no matching message arrives before the timeout elapses.
      * @see     https://mailosaur.com/docs/api/#operation/Messages_Get Retrieve a message docs
      * @example https://mailosaur.com/docs/api/#operation/Messages_Get
      */
@@ -48,11 +55,12 @@ class Messages extends AOperation
 
     /**
      * <strong>Retrieves the detail for a single email message.</strong>
-     * <p>Simply supply the unique identifier for the required message.</p>
+     * <p>Must be used in conjunction with either `all` or `search` in order to get the unique
+     * identifier for the required message. Simply supply the unique identifier for the required message.</p>
      *
-     * @param $id string message id
+     * @param string $id The unique identifier of the message to be retrieved.
      *
-     * @return Message
+     * @return Message The full message.
      * @throws MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Messages_Get Retrieve a message by ID docs
      * @example https://mailosaur.com/docs/api/#operation/Messages_Get
@@ -69,8 +77,9 @@ class Messages extends AOperation
      * <strong>Permanently deletes a message.</strong>
      * <p>This operation cannot be undone. Also deletes any attachments related to the message.</p>
      *
-     * @param $id string
+     * @param string $id The identifier of the message to be deleted.
      *
+     * @return void
      * @throws MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Messages_Delete Delete a message docs
      * @example https://mailosaur.com/docs/api/#operation/Messages_Delete
@@ -81,17 +90,19 @@ class Messages extends AOperation
     }
 
     /**
-     * <strong>List all messages</strong><br/>
+     * <strong>List all messages</strong>
+     * <p>Returns a list of your messages in summary form. The summaries are returned sorted by
+     * received date, with the most recently-received messages appearing first.</p>
      *
-     * @param string $server       The identifier of the server hosting the messages.
-     * @param int    $page         Used in conjunction with itemsPerPage to support pagination.
-     * @param int    $itemsPerPage A limit on the number of results to be returned per page.
-     *                             Can be set between 1 and 1000 items, the default is 50.
-     * @param string $dir          Optionally limits results based on the direction (`Sent` or
-     *                             `Received`), with the default being `Received`.
-     * @param \DateTime      $receivedAfter  Limits results to only messages received after this date/time.
+     * @param string    $server        The identifier of the server hosting the messages.
+     * @param int       $page          Used in conjunction with itemsPerPage to support pagination.
+     * @param int       $itemsPerPage  A limit on the number of results to be returned per page.
+     *                                 Can be set between 1 and 1000 items, the default is 50.
+     * @param \DateTime $receivedAfter Limits results to only messages received after this date/time.
+     * @param string    $dir           Optionally limits results based on the direction (`Sent` or
+     *                                 `Received`), with the default being `Received`.
      *
-     * @return MessageListResult
+     * @return MessageListResult The message summaries.
      * @throws MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Messages_List List all messages
      * @example https://mailosaur.com/docs/api/#operation/Messages_List
@@ -115,9 +126,11 @@ class Messages extends AOperation
 
     /**
      * <strong>Delete all messages</strong>
+     * <p>Permanently deletes all messages within a server. This operation cannot be undone.</p>
      *
      * @param string $server The identifier of the server to be emptied.
      *
+     * @return void
      * @throws MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Messages_DeleteAll Delete all messages
      * @example https://mailosaur.com/docs/api/#operation/Messages_DeleteAll
@@ -144,8 +157,9 @@ class Messages extends AOperation
      * @param string $dir                    Optionally limits results based on the direction (`Sent` or
      *                                       `Received`), with the default being `Received`.
      *
-     * @return MessageListResult
-     * @throws MailosaurException
+     * @return MessageListResult The matching message summaries.
+     * @throws MailosaurException With error type `search_timeout` if no matching message is found before the
+     *                            timeout elapses, unless `$errorOnTimeout` is set to false.
      */
     public function search($server, SearchCriteria $searchCriteria, $page = 0, $itemsPerPage = 50, $timeout = null, \DateTime $receivedAfter = null, $errorOnTimeout = true, $dir = null)
     {
@@ -217,14 +231,14 @@ class Messages extends AOperation
 
     /**
      * <strong>Create a message</strong>
-     * <p>Creates a new message that can be sent to a verified email address. This is 
+     * <p>Creates a new message that can be sent to a verified email address. This is
      * useful in scenarios where you want an email to trigger a workflow in your
      * product.</p>
      *
-     * @param $server
-     * @param $messageCreateOptions
+     * @param string               $server               The unique identifier of the required server.
+     * @param MessageCreateOptions $messageCreateOptions Options to use when creating a new message.
      *
-     * @return \Mailosaur\Models\Message
+     * @return \Mailosaur\Models\Message The newly-created message.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Messages_Create Create a message
      * @example https://mailosaur.com/docs/api/#operation/Messages_Create
@@ -253,12 +267,13 @@ class Messages extends AOperation
 
     /**
      * <strong>Forward an email</strong>
-     * <p>Forwards the specified email to a verified email address.</p>
+     * <p>Forwards the specified email to a verified email address. This is useful for simulating
+     * a user forwarding one of your email messages.</p>
      *
-     * @param $id
-     * @param $messageForwardOptions
+     * @param string                $id                    The unique identifier of the message to be forwarded.
+     * @param MessageForwardOptions $messageForwardOptions Options to use when forwarding a message.
      *
-     * @return \Mailosaur\Models\Message
+     * @return \Mailosaur\Models\Message The forwarded message.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Messages_Forward Forward an email
      * @example https://mailosaur.com/docs/api/#operation/Messages_Forward
@@ -283,13 +298,13 @@ class Messages extends AOperation
 
     /**
      * <strong>Reply to an email</strong>
-     * <p>Sends a reply to the specified email. This is useful for when 
-     * simulating a user replying to one of your emails.</p>
+     * <p>Sends a reply to the specified message. This is useful for when
+     * simulating a user replying to one of your email or SMS messages.</p>
      *
-     * @param $id
-     * @param $messageReplyOptions
+     * @param string              $id                  The unique identifier of the message to be replied to.
+     * @param MessageReplyOptions $messageReplyOptions Options to use when replying to a message.
      *
-     * @return \Mailosaur\Models\Message
+     * @return \Mailosaur\Models\Message The reply message.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Messages_Reply Reply to an email
      * @example https://mailosaur.com/docs/api/#operation/Messages_Reply
@@ -316,10 +331,10 @@ class Messages extends AOperation
      * <strong>Generate email previews</strong>
      * <p>Generates screenshots of an email rendered in the specified email clients.</p>
      *
-     * @param $id
-     * @param $options
+     * @param string                $id      The identifier of the email to preview.
+     * @param PreviewRequestOptions $options The options with which to generate previews.
      *
-     * @return \Mailosaur\Models\PreviewListResult
+     * @return \Mailosaur\Models\PreviewListResult The generated previews.
      * @throws \Mailosaur\Models\MailosaurException
      */
     public function generatePreviews($id, PreviewRequestOptions $options)

--- a/src/Operations/Previews.php
+++ b/src/Operations/Previews.php
@@ -5,13 +5,18 @@ namespace Mailosaur\Operations;
 
 use Mailosaur\Models\EmailClientListResult;
 
+/**
+ * Operations for discovering the email clients available for generating email previews
+ * (screenshots of an email rendered in real clients). Accessed via `client->previews`.
+ */
 class Previews extends AOperation
 {
 
     /**
      * <strong>List all email preview clients</strong>
+     * <p>Lists all email clients that can be used to generate email previews.</p>
      *
-     * @return EmailClientListResult
+     * @return EmailClientListResult The available email clients.
      * @throws \Mailosaur\Models\MailosaurException
      */
     public function allEmailClients()

--- a/src/Operations/Servers.php
+++ b/src/Operations/Servers.php
@@ -14,7 +14,7 @@ use Mailosaur\Models\ServerCreateOptions;
 use Mailosaur\Models\ServerListResult;
 
 /**
- * Operations for creating and managing your Mailosaur servers — the virtual inboxes that group
+ * Operations for creating and managing your Mailosaur inboxes (servers) — they group
  * your tests together, each with its own domain and SMTP/POP3/IMAP credentials. Accessed via
  * `client->servers`.
  */
@@ -23,9 +23,9 @@ class Servers extends AOperation
 
     /**
      * <strong>List all servers</strong>
-     * <p>Returns a list of your virtual servers. Servers are returned sorted in alphabetical order.</p>
+     * <p>Returns a list of your inboxes (servers). Inboxes (servers) are returned sorted in alphabetical order.</p>
      *
-     * @return ServerListResult Your servers.
+     * @return ServerListResult Your inboxes (servers).
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_List List all servers
      * @example https://mailosaur.com/docs/api/#operation/Servers_List
@@ -41,11 +41,11 @@ class Servers extends AOperation
 
     /**
      * <strong>Create a server</strong>
-     * <p>Creates a new virtual server and returns it.</p>
+     * <p>Creates a new inbox (server) and returns it.</p>
      *
-     * @param ServerCreateOptions $serverCreateOptions Options used to create a new Mailosaur server.
+     * @param ServerCreateOptions $serverCreateOptions Options used to create a new Mailosaur inbox (server).
      *
-     * @return \Mailosaur\Models\Server The newly-created server.
+     * @return \Mailosaur\Models\Server The newly-created inbox (server).
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_Create Create a server
      * @example https://mailosaur.com/docs/api/#operation/Servers_Create
@@ -70,11 +70,11 @@ class Servers extends AOperation
 
     /**
      * <strong>Retrieve a server</strong>
-     * <p>Retrieves the detail for a single server.</p>
+     * <p>Retrieves the detail for a single inbox (server).</p>
      *
-     * @param string $id The unique identifier of the server to be retrieved.
+     * @param string $id The unique identifier of the inbox (server) to be retrieved.
      *
-     * @return \Mailosaur\Models\Server The server.
+     * @return \Mailosaur\Models\Server The inbox (server).
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_Get Retrieve a server
      * @example https://mailosaur.com/docs/api/#operation/Servers_Get
@@ -90,11 +90,11 @@ class Servers extends AOperation
 
     /**
      * <strong>Retrieve server password</strong>
-     * <p>Retrieves the password for a server. This password can be used for SMTP, POP3, and IMAP connectivity.</p>
+     * <p>Retrieves the password for an inbox (server). This password can be used for SMTP, POP3, and IMAP connectivity.</p>
      *
-     * @param string $id The unique identifier of the server.
+     * @param string $id The unique identifier of the inbox (server).
      *
-     * @return string The server's password.
+     * @return string The password for the inbox (server).
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_Get_Password Retrieve server password
      * @example https://mailosaur.com/docs/api/#operation/Servers_Get_Password
@@ -110,12 +110,12 @@ class Servers extends AOperation
 
     /**
      * <strong>Update a server</strong>
-     * <p>Updates the attributes of a server and returns it.</p>
+     * <p>Updates the attributes of an inbox (server) and returns it.</p>
      *
-     * @param string                   $id     The unique identifier of the server to be updated.
-     * @param \Mailosaur\Models\Server $server The updated server.
+     * @param string                   $id     The unique identifier of the inbox (server) to be updated.
+     * @param \Mailosaur\Models\Server $server The updated inbox (server).
      *
-     * @return \Mailosaur\Models\Server The updated server.
+     * @return \Mailosaur\Models\Server The updated inbox (server).
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_Update Update a server docs
      * @example https://mailosaur.com/docs/api/#operation/Servers_Update
@@ -140,10 +140,10 @@ class Servers extends AOperation
 
     /**
      * <strong>Delete a server</strong>
-     * <p>Permanently deletes a server. This will also delete all messages, associated attachments,
-     * etc. within the server. This operation cannot be undone.</p>
+     * <p>Permanently deletes an inbox (server). This will also delete all messages, associated attachments,
+     * etc. within the inbox (server). This operation cannot be undone.</p>
      *
-     * @param string $id The unique identifier of the server to be deleted.
+     * @param string $id The unique identifier of the inbox (server) to be deleted.
      *
      * @return void
      * @throws \Mailosaur\Models\MailosaurException
@@ -157,12 +157,12 @@ class Servers extends AOperation
 
     /**
      * <strong>Generate a random email address</strong>
-     * <p>Generates a random email address by appending a random string in front of the server's
-     * domain name.</p>
+     * <p>Generates a random email address by appending a random string in front of the
+     * domain name of the inbox (server).</p>
      *
-     * @param string $server The identifier of the server.
+     * @param string $server The identifier of the inbox (server).
      *
-     * @return string A random email address ending in the server's domain.
+     * @return string A random email address ending in the domain of the inbox (server).
      */
     public function generateEmailAddress($server)
     {

--- a/src/Operations/Servers.php
+++ b/src/Operations/Servers.php
@@ -13,13 +13,19 @@ use Mailosaur\Models\Server;
 use Mailosaur\Models\ServerCreateOptions;
 use Mailosaur\Models\ServerListResult;
 
+/**
+ * Operations for creating and managing your Mailosaur servers — the virtual inboxes that group
+ * your tests together, each with its own domain and SMTP/POP3/IMAP credentials. Accessed via
+ * `client->servers`.
+ */
 class Servers extends AOperation
 {
 
     /**
      * <strong>List all servers</strong>
+     * <p>Returns a list of your virtual servers. Servers are returned sorted in alphabetical order.</p>
      *
-     * @return ServerListResult
+     * @return ServerListResult Your servers.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_List List all servers
      * @example https://mailosaur.com/docs/api/#operation/Servers_List
@@ -35,11 +41,11 @@ class Servers extends AOperation
 
     /**
      * <strong>Create a server</strong>
-     * <p>Creates a new virtual SMTP server and returns it.</p>
+     * <p>Creates a new virtual server and returns it.</p>
      *
-     * @param $serverCreateOptions
+     * @param ServerCreateOptions $serverCreateOptions Options used to create a new Mailosaur server.
      *
-     * @return \Mailosaur\Models\Server
+     * @return \Mailosaur\Models\Server The newly-created server.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_Create Create a server
      * @example https://mailosaur.com/docs/api/#operation/Servers_Create
@@ -64,10 +70,11 @@ class Servers extends AOperation
 
     /**
      * <strong>Retrieve a server</strong>
+     * <p>Retrieves the detail for a single server.</p>
      *
-     * @param string $id The identifier of the server to be retrieved.
+     * @param string $id The unique identifier of the server to be retrieved.
      *
-     * @return \Mailosaur\Models\Server
+     * @return \Mailosaur\Models\Server The server.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_Get Retrieve a server
      * @example https://mailosaur.com/docs/api/#operation/Servers_Get
@@ -83,10 +90,11 @@ class Servers extends AOperation
 
     /**
      * <strong>Retrieve server password</strong>
+     * <p>Retrieves the password for a server. This password can be used for SMTP, POP3, and IMAP connectivity.</p>
      *
-     * @param string $id The identifier of the server.
+     * @param string $id The unique identifier of the server.
      *
-     * @return string
+     * @return string The server's password.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_Get_Password Retrieve server password
      * @example https://mailosaur.com/docs/api/#operation/Servers_Get_Password
@@ -102,12 +110,12 @@ class Servers extends AOperation
 
     /**
      * <strong>Update a server</strong>
-     * <p>Updates a single server and returns it.</p>
+     * <p>Updates the attributes of a server and returns it.</p>
      *
-     * @param string                   $id The identifier of the server to be updated.
-     * @param \Mailosaur\Models\Server $server
+     * @param string                   $id     The unique identifier of the server to be updated.
+     * @param \Mailosaur\Models\Server $server The updated server.
      *
-     * @return \Mailosaur\Models\Server
+     * @return \Mailosaur\Models\Server The updated server.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_Update Update a server docs
      * @example https://mailosaur.com/docs/api/#operation/Servers_Update
@@ -132,9 +140,12 @@ class Servers extends AOperation
 
     /**
      * <strong>Delete a server</strong>
+     * <p>Permanently deletes a server. This will also delete all messages, associated attachments,
+     * etc. within the server. This operation cannot be undone.</p>
      *
-     * @param string $id The identifier of the server to be deleted.
+     * @param string $id The unique identifier of the server to be deleted.
      *
+     * @return void
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#operation/Servers_Delete Delete a server
      * @example https://mailosaur.com/docs/api/#operation/Servers_Delete
@@ -144,6 +155,15 @@ class Servers extends AOperation
         $this->request('api/servers/' . urlencode($id), array(CURLOPT_CUSTOMREQUEST => 'DELETE'));
     }
 
+    /**
+     * <strong>Generate a random email address</strong>
+     * <p>Generates a random email address by appending a random string in front of the server's
+     * domain name.</p>
+     *
+     * @param string $server The identifier of the server.
+     *
+     * @return string A random email address ending in the server's domain.
+     */
     public function generateEmailAddress($server)
     {
         $host = ($h = getenv('MAILOSAUR_SMTP_HOST')) ? $h : 'mailosaur.net';

--- a/src/Operations/Usage.php
+++ b/src/Operations/Usage.php
@@ -11,13 +11,19 @@ namespace Mailosaur\Operations;
 use Mailosaur\Models\UsageAccountLimits;
 use Mailosaur\Models\UsageTransactionListResult;
 
+/**
+ * Operations for inspecting your account's usage limits and recent transactional usage. These
+ * endpoints require authentication with an account-level API key. Accessed via `client->usage`.
+ */
 class Usage extends AOperation
 {
 
     /**
      * <strong>Retrieve account limits</strong>
+     * <p>Retrieves account usage limits, detailing the current limits and usage for your account.
+     * This endpoint requires authentication with an account-level API key.</p>
      *
-     * @return UsageAccountLimits
+     * @return UsageAccountLimits The usage limits for your account.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#usage Retrieve account limits
      * @example https://mailosaur.com/docs/api/#usage
@@ -33,8 +39,10 @@ class Usage extends AOperation
 
     /**
      * <strong>List usage transactions</strong>
+     * <p>Retrieves the last 31 days of transactional usage. This endpoint requires authentication
+     * with an account-level API key.</p>
      *
-     * @return UsageTransactionListResult
+     * @return UsageTransactionListResult The transactional usage for the last 31 days.
      * @throws \Mailosaur\Models\MailosaurException
      * @see     https://mailosaur.com/docs/api/#usage Retrieve account limits
      * @example https://mailosaur.com/docs/api/#usage


### PR DESCRIPTION
## Summary

- Add and expand Intellisense doc comments across the client and operations classes (descriptions, parameters, and return values).
- Adopt **inbox (server)** terminology in the doc-comment prose, so hover documentation matches the dashboard UI.

## Scope

- Doc comments only — no code, public API, or behaviour changes.
- Parameter names, type names, and other code identifiers are unchanged.
